### PR TITLE
Added an optimized method to extract file by chunks via un std::ofstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=g++
-CFLAGS=-W -Wall -Wextra -ansi -pedantic
+CFLAGS=-W -Wall -Wextra -ansi -pedantic -std=c++11
 OBJ=obj
 LIB=lib
 ZLIB_VERSION=1.2.8

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=g++
-CFLAGS=-W -Wall -Wextra -ansi -pedantic -std=c++11
+CFLAGS=-W -Wall -Wextra -ansi -pedantic
 OBJ=obj
 LIB=lib
 ZLIB_VERSION=1.2.8

--- a/src/libzippp.cpp
+++ b/src/libzippp.cpp
@@ -496,31 +496,32 @@ bool ZipArchive::writeOfstream(const ZipEntry& zipEntry, std::ofstream& ofOutput
 
       if (maxSize < chunksize)
       {
-         std::unique_ptr<char[]> data(new char[maxSize]);
-         if (data.get() != NULL)
+         char* data = new char[maxSize];
+         if (data != NULL)
          {
-            libzippp_int64 result = zip_fread(zipFile, data.get(), maxSize);
+            libzippp_int64 result = zip_fread(zipFile, data, maxSize);
             if (result == static_cast<libzippp_int64>(maxSize))
             {
-               ofOutput.write(data.get(), maxSize);
+               ofOutput.write(data, maxSize);
                bRes = true;
             }
+            delete[] data;
          }
       }
       else
       {
          libzippp_uint64 uWrittenBytes = 0;
          libzippp_int64 result = 0;
-         std::unique_ptr<char[]> data(new char[chunksize]);
-         for (unsigned int uiChunk = 0; uiChunk < maxSize / chunksize; ++uiChunk)
+         char* data = new char[chunksize];
+         for (unsigned int uiChunk = 0; data && uiChunk < maxSize / chunksize; ++uiChunk)
          {
-            if (data.get() != nullptr)
+            if (data != NULL)
             {
-               result = zip_fread(zipFile, data.get(), chunksize);
+               result = zip_fread(zipFile, data, chunksize);
                if (result > 0)
                {
                   uWrittenBytes += result;
-                  ofOutput.write(data.get(), chunksize);
+                  ofOutput.write(data, chunksize);
                }
                else
                   break;
@@ -529,17 +530,20 @@ bool ZipArchive::writeOfstream(const ZipEntry& zipEntry, std::ofstream& ofOutput
                   break;
             }
          }
+         if (data != NULL)
+            delete[] data;
          if (ofOutput && result > 0 && maxSize % chunksize > 0)
          {
-            std::unique_ptr<char[]> data(new char[maxSize % chunksize]);
-            if (data.get() != nullptr)
+            char* data = new char[maxSize % chunksize];
+            if (data != NULL)
             {
-               result = zip_fread(zipFile, data.get(), maxSize % chunksize);
+               result = zip_fread(zipFile, data, maxSize % chunksize);
                if (result > 0)
                {
                   uWrittenBytes += result;
-                  ofOutput.write(data.get(), maxSize % chunksize);
+                  ofOutput.write(data, maxSize % chunksize);
                }
+               delete[] data;
             }
          }
          if (uWrittenBytes == maxSize)

--- a/src/libzippp.cpp
+++ b/src/libzippp.cpp
@@ -511,9 +511,9 @@ bool ZipArchive::writeOfstream(const ZipEntry& zipEntry, std::ofstream& ofOutput
       {
          size_t uWrittenBytes = 0;
          libzippp_int64 result;
+         std::unique_ptr<char[]> data(new char[chunksize]);
          for (unsigned int uiChunk = 0; uiChunk < maxSize / chunksize; ++uiChunk)
          {
-            std::unique_ptr<char[]> data(new char[chunksize]);
             if (data.get() != nullptr)
             {
                result = zip_fread(zipFile, data.get(), chunksize);

--- a/src/libzippp.cpp
+++ b/src/libzippp.cpp
@@ -510,7 +510,7 @@ bool ZipArchive::writeOfstream(const ZipEntry& zipEntry, std::ofstream& ofOutput
       else
       {
          libzippp_uint64 uWrittenBytes = 0;
-         libzippp_int64 result;
+         libzippp_int64 result = 0;
          std::unique_ptr<char[]> data(new char[chunksize]);
          for (unsigned int uiChunk = 0; uiChunk < maxSize / chunksize; ++uiChunk)
          {

--- a/src/libzippp.h
+++ b/src/libzippp.h
@@ -264,8 +264,8 @@ namespace libzippp {
          * opened std::ofstream, gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
          * The method returns 0 if the extraction has succeeded with no problems, -1 if the ofstream is not opened,
          * -2 if the archive is not opened, -3 if the zipEntry doesn't belong to the archive, -4 if zip_fopen_index()
-         * has failed, -5 if a memory allocation has failed, -6 if zip_fread didn't succed to read data, -7 if the last
-         * ofstream operation has failed and -8 if fread() didn't return the exact amount of bytes and -9 if the amount
+         * has failed, -5 if a memory allocation has failed, -6 if zip_fread() didn't succeed to read data, -7 if the last
+         * ofstream operation has failed, -8 if fread() didn't return the exact amount of requested bytes and -9 if the amount
          * of extracted bytes didn't match the size of the file (unknown error).
          * If the provided chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE (512KB).
          * The method doesn't close the ofstream after the extraction.
@@ -459,7 +459,7 @@ namespace libzippp {
          * opened std::ofstream, gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
          * The method returns 0 if the extraction has succeeded with no problems, -1 if the ofstream is not opened,
          * -2 if the archive is not opened, -3 if the zipEntry doesn't belong to the archive, -4 if zip_fopen_index()
-         * has failed, -5 if a memory allocation has failed, -6 if zip_fread didn't succed to read data, -7 if the last
+         * has failed, -5 if a memory allocation has failed, -6 if zip_fread() didn't succeed to read data, -7 if the last
          * ofstream operation has failed, -8 if fread() didn't return the exact amount of requested bytes and -9 if the amount
          * of extracted bytes didn't match the size of the file (unknown error).
          * If the provided chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE (512KB).

--- a/src/libzippp.h
+++ b/src/libzippp.h
@@ -260,6 +260,19 @@ namespace libzippp {
         void* readEntry(const std::string& zipEntry, bool asText=false, State state=CURRENT, libzippp_uint64 size=0) const;
         
         /**
+         * Read the specified ZipEntry of the ZipArchive and inserts its content in the provided reference to an already
+         * opened std::ofstream, gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
+         * The method returns 0 if the extraction has succeeded with no problems, -1 if the ofstream is not opened,
+         * -2 if the archive is not opened, -3 if the zipEntry doesn't belong to the archive, -4 if zip_fopen_index()
+         * has failed, -5 if a memory allocation has failed, -6 if zip_fread didn't succed to read data, -7 if the last
+         * ofstream operation has failed and -8 if fread() didn't return the exact amount of bytes and -9 if the amount
+         * of extracted bytes didn't match the size of the file (unknown error).
+         * If the provided chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE (512KB).
+         * The method doesn't close the ofstream after the extraction.
+         */
+        int readEntry(const ZipEntry& zipEntry, std::ofstream& ofOutput, State state=CURRENT, libzippp_uint64 chunksize=DEFAULT_CHUNK_SIZE) const;
+
+        /**
          * Deletes the specified entry from the zip file. If the entry is a folder, all its
          * subentries will be removed. This method returns the number of entries removed.
          * If the open mode does not allow a deletion, this method will return  -1. If an
@@ -336,14 +349,6 @@ namespace libzippp {
          * If the archive is not open, then NOT_OPEN will be returned.
          */
         OpenMode getMode(void) const { return mode; }
-
-        /**
-        * Writes the content of a ZipEntry as binary through a reference to an already opened std::ofstream,
-        * gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
-        * true should be returned if the extraction has succeeded.
-        * If the chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE.
-        */
-        bool writeOfstream(const ZipEntry& zipEntry, std::ofstream& ofOutput, State state=CURRENT, libzippp_uint64 chunksize=DEFAULT_CHUNK_SIZE) const;
 
     private:
         std::string path;
@@ -450,12 +455,17 @@ namespace libzippp {
         void* readAsBinary(ZipArchive::State state=ZipArchive::CURRENT, libzippp_uint64 size=0) const;
         
         /**
-        * Writes the content of this ZipEntry as binary through a reference to an already opened std::ofstream,
-        * gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
-        * true should be returned if the extraction has succeeded.
-        * If the chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE.
-        */
-        bool extractFile(std::ofstream& ofOutput, ZipArchive::State state=ZipArchive::CURRENT, libzippp_uint64 chunksize=DEFAULT_CHUNK_SIZE) const;
+         * Read the specified ZipEntry of the ZipArchive and inserts its content in the provided reference to an already
+         * opened std::ofstream, gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
+         * The method returns 0 if the extraction has succeeded with no problems, -1 if the ofstream is not opened,
+         * -2 if the archive is not opened, -3 if the zipEntry doesn't belong to the archive, -4 if zip_fopen_index()
+         * has failed, -5 if a memory allocation has failed, -6 if zip_fread didn't succed to read data, -7 if the last
+         * ofstream operation has failed, -8 if fread() didn't return the exact amount of requested bytes and -9 if the amount
+         * of extracted bytes didn't match the size of the file (unknown error).
+         * If the provided chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE (512KB).
+         * The method doesn't close the ofstream after the extraction.
+         */
+        int readContent(std::ofstream& ofOutput, ZipArchive::State state=ZipArchive::CURRENT, libzippp_uint64 chunksize=DEFAULT_CHUNK_SIZE) const;
         
     private:
         const ZipArchive* zipFile;

--- a/src/libzippp.h
+++ b/src/libzippp.h
@@ -44,6 +44,7 @@ struct zip;
 
 #define DIRECTORY_SEPARATOR '/'
 #define IS_DIRECTORY(str) (str.length()>0 && str[str.length()-1]==DIRECTORY_SEPARATOR)
+#define DEFAULT_CHUNK_SIZE 524288
 
 // documentation
 // http://www.nih.at/libzip/libzip.html
@@ -335,7 +336,15 @@ namespace libzippp {
          * If the archive is not open, then NOT_OPEN will be returned.
          */
         OpenMode getMode(void) const { return mode; }
-        
+
+        /**
+        * Writes the content of a ZipEntry as binary through a reference to an already opened std::ofstream,
+        * gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
+        * true should be returned if the extraction has succeeded.
+        * If the chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE.
+        */
+        bool writeOfstream(const ZipEntry& zipEntry, std::ofstream& ofOutput, State state=CURRENT, libzippp_uint64 chunksize=DEFAULT_CHUNK_SIZE) const;
+
     private:
         std::string path;
         zip* zipHandle;
@@ -439,6 +448,14 @@ namespace libzippp {
          * This method is a wrapper around ZipArchive::readEntry(...).
          */
         void* readAsBinary(ZipArchive::State state=ZipArchive::CURRENT, libzippp_uint64 size=0) const;
+        
+        /**
+        * Writes the content of this ZipEntry as binary through a reference to an already opened std::ofstream,
+        * gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
+        * true should be returned if the extraction has succeeded.
+        * If the chunk size is zero, it will be defaulted to DEFAULT_CHUNK_SIZE.
+        */
+        bool extractFile(std::ofstream& ofOutput, ZipArchive::State state=ZipArchive::CURRENT, libzippp_uint64 chunksize=DEFAULT_CHUNK_SIZE) const;
         
     private:
         const ZipArchive* zipFile;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -602,7 +602,7 @@ void test20() {
     // Extract somedata with chunk of 2 bytes, which is not divisible by the file size (17 Bytes)
     std::ofstream ofUnzippedFile("somedata.txt");
     assert(static_cast<bool>(ofUnzippedFile));
-    assert(entry.extractFile(ofUnzippedFile, ZipArchive::CURRENT, 2));
+    assert(entry.readContent(ofUnzippedFile, ZipArchive::CURRENT, 2) == 0);
     ofUnzippedFile.close();
 
     std::ifstream ifUnzippedFile("somedata.txt");
@@ -617,7 +617,7 @@ void test20() {
     // Extract somedata with chunk of 0 bytes (will be defaulted to 512KB).
     std::ofstream ofUnzippedFile("somedata.txt");
     assert(static_cast<bool>(ofUnzippedFile));
-    assert(entry.extractFile(ofUnzippedFile, ZipArchive::CURRENT, 0));
+    assert(entry.readContent(ofUnzippedFile, ZipArchive::CURRENT, 0) == 0);
     ofUnzippedFile.close();
 
     std::ifstream ifUnzippedFile("somedata.txt");
@@ -633,7 +633,7 @@ void test20() {
     // is not accessed !
     std::ofstream ofUnzippedFile("somedata2.txt");
     assert(static_cast<bool>(ofUnzippedFile));
-    assert(entry2.extractFile(ofUnzippedFile, ZipArchive::CURRENT, 2));
+    assert(entry2.readContent(ofUnzippedFile, ZipArchive::CURRENT, 2) == 0);
     ofUnzippedFile.close();
 
     std::ifstream ifUnzippedFile("somedata2.txt");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -36,7 +36,10 @@
 #include <assert.h>
 #include <string.h>
 #include <iostream>
+#include <iterator>
+#include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <string>
 
 #include "libzippp.h"
@@ -570,11 +573,88 @@ void test19() {
     cout << " done." << endl;
 }
 
+void test20() {
+    cout << "Running test 20...";
+
+    const char* txtFile = "this is some data";   // 17 Bytes
+    const char* txtFile2 = "this is some data!"; // 18 Bytes
+    int len = strlen(txtFile);
+    int len2 = strlen(txtFile2);
+    
+    ZipArchive z1("test.zip");
+    z1.open(ZipArchive::WRITE);
+    z1.addData("somedata", txtFile, len);
+    z1.addData("somedata2", txtFile2, len2);
+    z1.close();
+    
+    ZipArchive z2("test.zip");
+    z2.open(ZipArchive::READ_ONLY);
+    assert(z2.getNbEntries()==2);
+    assert(z2.hasEntry("somedata"));
+    assert(z2.hasEntry("somedata2"));
+    
+    ZipEntry entry = z2.getEntry("somedata");
+    ZipEntry entry2 = z2.getEntry("somedata2");
+    assert(!entry.isNull());
+    assert(!entry2.isNull());
+    
+    {
+    // Extract somedata with chunk of 2 bytes, which is not divisible by the file size (17 Bytes)
+    std::ofstream ofUnzippedFile("somedata.txt");
+    assert(static_cast<bool>(ofUnzippedFile));
+    assert(entry.extractFile(ofUnzippedFile, ZipArchive::CURRENT, 2));
+    ofUnzippedFile.close();
+
+    std::ifstream ifUnzippedFile("somedata.txt");
+    assert(static_cast<bool>(ifUnzippedFile));
+    std::string strSomedataText((std::istreambuf_iterator<char>(ifUnzippedFile)), std::istreambuf_iterator<char>());
+    assert(strSomedataText.compare(txtFile) == 0);
+    ifUnzippedFile.close();
+    assert(remove("somedata.txt") == 0);
+    }
+
+    {
+    // Extract somedata with chunk of 0 bytes (will be defaulted to 512KB).
+    std::ofstream ofUnzippedFile("somedata.txt");
+    assert(static_cast<bool>(ofUnzippedFile));
+    assert(entry.extractFile(ofUnzippedFile, ZipArchive::CURRENT, 0));
+    ofUnzippedFile.close();
+
+    std::ifstream ifUnzippedFile("somedata.txt");
+    assert(static_cast<bool>(ifUnzippedFile));
+    std::string strSomedataText((std::istreambuf_iterator<char>(ifUnzippedFile)), std::istreambuf_iterator<char>());
+    assert(strSomedataText.compare(txtFile) == 0);
+    ifUnzippedFile.close();
+    assert(remove("somedata.txt") == 0);
+    }
+
+    {
+    // Extract somedata2 with a chunk which is divisible by the size of the file (18 Bytes) to check that the modulo branch
+    // is not accessed !
+    std::ofstream ofUnzippedFile("somedata2.txt");
+    assert(static_cast<bool>(ofUnzippedFile));
+    assert(entry2.extractFile(ofUnzippedFile, ZipArchive::CURRENT, 2));
+    ofUnzippedFile.close();
+
+    std::ifstream ifUnzippedFile("somedata2.txt");
+    assert(static_cast<bool>(ifUnzippedFile));
+    std::string strSomedataText((std::istreambuf_iterator<char>(ifUnzippedFile)), std::istreambuf_iterator<char>());
+    assert(strSomedataText.compare(txtFile2) == 0);
+    ifUnzippedFile.close();
+    assert(remove("somedata2.txt") == 0);
+    }
+
+    z2.close();
+    z2.unlink();
+    
+    cout << " done." << endl;
+}
+
 int main(int argc, char** argv) {
     test1();  test2();  test3();  test4();  test5();
     test6();  test7();  test8();  test9();  test10();
     test11(); test12(); test13(); test14(); test15();
-    test16(); test17(); test18(); test19();
+    test16(); test17(); test18(); test19(); test20();
 }
 
 


### PR DESCRIPTION
ZipEntry::extractFile writes the content of a ZipEntry as binary through a reference to an already opened std::ofstream, gradually, with chunks of size "chunksize" to reduce memory usage when dealing with big files.
true should be returned if the extraction has succeeded.
if the chunk size is zero or is not provided, it will be defaulted to DEFAULT_CHUNK_SIZE (512 KBytes).

The purpose of such method is to enhance memory usage when extracting a big file but especially this method will allow the extraction of big files in systems having a limited amount of memory.