### PR TITLE
Forces the use of OpenSSL as crypto library to be used in libzip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ZLIB_VERSION=1.2.11
 ZLIB=$(LIB)/zlib-$(ZLIB_VERSION)
 LIBZIP_VERSION=1.5.1
 LIBZIP=$(LIB)/libzip-$(LIBZIP_VERSION)
+LIBZIP_CMAKE=-DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF 
 CRYPTO_FLAGS=-lssl -lcrypto
 
 # for optimal compilation speed, should be <nb_proc>+1
@@ -90,16 +91,16 @@ libzip-build-folder:
 
 libzip-build-shared: libzip-patch libzip-build-folder
 	if [ -d "$(ZLIB)" ]; then \
-		cd $(LIBZIP)/build && cmake .. -DZLIB_LIBRARY_RELEASE=../../../$(ZLIB)/libz.so -DZLIB_INCLUDE_DIR=../../../$(ZLIB) -DBUILD_SHARED_LIBS=ON && make -j$(NBPROC);  \
+		cd $(LIBZIP)/build && cmake .. -DZLIB_LIBRARY_RELEASE=../../../$(ZLIB)/libz.so -DZLIB_INCLUDE_DIR=../../../$(ZLIB) -DBUILD_SHARED_LIBS=ON $(LIBZIP_CMAKE) && make -j$(NBPROC);  \
 	else \
-		cd $(LIBZIP)/build && cmake .. -DBUILD_SHARED_LIBS=ON && make -j$(NBPROC);  \
+		cd $(LIBZIP)/build && cmake .. -DBUILD_SHARED_LIBS=ON $(LIBZIP_CMAKE) && make -j$(NBPROC);  \
 	fi;
 	
 libzip-build-static: libzip-patch libzip-build-folder
 	if [ -d "$(ZLIB)" ]; then \
-		cd $(LIBZIP)/build && cmake .. -DZLIB_LIBRARY_RELEASE=../../../$(ZLIB)/libz.a -DZLIB_INCLUDE_DIR=../../../$(ZLIB) -DBUILD_SHARED_LIBS=OFF && make -j$(NBPROC);  \
+		cd $(LIBZIP)/build && cmake .. -DZLIB_LIBRARY_RELEASE=../../../$(ZLIB)/libz.a -DZLIB_INCLUDE_DIR=../../../$(ZLIB) -DBUILD_SHARED_LIBS=OFF $(LIBZIP_CMAKE) && make -j$(NBPROC);  \
 	else \
-		cd $(LIBZIP)/build && cmake .. -DBUILD_SHARED_LIBS=OFF && make -j$(NBPROC);  \
+		cd $(LIBZIP)/build && cmake .. -DBUILD_SHARED_LIBS=OFF $(LIBZIP_CMAKE) && make -j$(NBPROC);  \
 	fi;
 
 libzip: libzip-build-shared libzip-build-static

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ g++ -I./lib/libzip-1.5.1/lib -I./src \
 
 Since version 1.5, libzip uses an underlying cryptographic library (OpenSSL, GNUTLS or CommonCrypto) that
 is necessary for static compilation. By default, libzippp will use `-lssl -lcrypto` (OpenSSL) as default flags
-to compile the tests. This can be changed by using `make CRYPTO_FLAGS=-lsome_lib tests`
+to compile the tests. This can be changed by using `make CRYPTO_FLAGS="-lsome_lib" LIBZIP_CMAKE="" tests`.
+
+Since libzip `cmake`'s file detects automatically the cryptographic library to use, by default all the allowed
+libraries but OpenSSL are explicitely disabled in the `LIBZIP_CMAKE` variable in the Makefile.
 
 See [here](https://github.com/nih-at/libzip/blob/master/INSTALL.md) for more information.
 


### PR DESCRIPTION
I've seen by moving to libzip version 1.5.2 that it wanted to use gnutls, which is not compatible with the default Makefile variables.