### PR TITLE
Fix minor leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ clean-tests:
 	@rm -rf *.zip
 
 tests: libzippp-tests clean-tests
-	LD_LIBRARY_PATH="$(LIBZIP)/build/lib" valgrind --suppressions=ld.supp ./test_shared
-	valgrind --suppressions=ld.supp ./test_static
+	LD_LIBRARY_PATH="$(LIBZIP)/build/lib" valgrind --suppressions=ld.supp --leak-check=full ./test_shared
+	valgrind --suppressions=ld.supp --leak-check=full ./test_static
 
 clean:
 	@rm -rf libzippp.a libzippp.so

--- a/src/libzippp.cpp
+++ b/src/libzippp.cpp
@@ -177,7 +177,7 @@ bool ZipArchive::open(OpenMode om, bool checkConsistency) {
     zipHandle = zip_open(path.c_str(), zipFlag, &errorFlag);
     
     //error during opening of the file
-    if(errorFlag!=ZIP_ER_OK) {
+    if (errorFlag!=ZIP_ER_OK) {
         /*char* errorStr = new char[256];
         zip_error_to_str(errorStr, 255, errorFlag, errno);
         errorStr[255] = '\0';
@@ -208,17 +208,17 @@ bool ZipArchive::open(OpenMode om, bool checkConsistency) {
 int ZipArchive::close(void) {
     if (isOpen()) {
 
-        if (zipSource){
-            //zip_source_close(zipSource);
-            //zip_source_free(zipSource);
-            //zipSource = nullptr;
+        if (zipSource) {
+            //no free here because it should not be done once successfully used in zip_open_from_source
+            zip_source_close(zipSource);
+            zipSource = nullptr;
         }
 
         int result = zip_close(zipHandle);
         zipHandle = nullptr;
         mode = NotOpen;
         
-        if(result!=0) { return result; }
+        if (result!=0) { return result; }
     }
     
     return LIBZIPPP_OK;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -692,6 +692,8 @@ void test21() {
     z2->close();
     delete z2;
 
+    free(buffer);
+
     cout << " done." << endl;
 }
 


### PR DESCRIPTION
* Enables Valgrind full checks
* Fixes memory leak in tests (introduced in #38)
* Fixes non-closed zip source when `ZipArchive::fromBuffer` was used (introduced in #38)