### PR TITLE
Avoids useless read of file length when adding a file to archive

### DIFF
--- a/src/libzippp.cpp
+++ b/src/libzippp.cpp
@@ -542,14 +542,8 @@ bool ZipArchive::addFile(const string& entryName, const string& file) const {
         if (!dadded) { return false; }
     }
     
-    //retrieves the length of the file
-    //http://stackoverflow.com/questions/5840148/how-can-i-get-a-files-size-in-c
     const char* filepath = file.c_str();
-    ifstream in(filepath, ifstream::in | ifstream::binary);
-    in.seekg(0, ifstream::end);
-    streampos end = in.tellg();
-    
-    zip_source* source = zip_source_file(zipHandle, filepath, 0, end);
+    zip_source* source = zip_source_file(zipHandle, filepath, 0, -1);
     if (source!=nullptr) {
         libzippp_int64 result = zip_file_add(zipHandle, entryName.c_str(), source, ZIP_FL_OVERWRITE);
         if (result>=0) {


### PR DESCRIPTION
Fixes #104