### PR TITLE
Fixes for packaging on GNU/Unix like systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,21 +23,31 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -ansi -pedantic -std=c++11")
   set(CMAKE_CXX_FLAGS_DEBUG "-g")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+  set(NOTWIN32 ON)
 endif()
 
 option(LIBZIPPP_INSTALL "Install library" ${is_root_project})
 option(LIBZIPPP_INSTALL_HEADERS "Install the headers" ${is_root_project})
 option(LIBZIPPP_BUILD_TESTS "Build unit tests" ${is_root_project})
 option(LIBZIPPP_ENABLE_ENCRYPTION "Build with encryption enabled" OFF)
+option(LIBZIPPP_CMAKE_CONFIG_MODE "Build with libzip installed cmake config files" ${NOTWIN32})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-find_package(LIBZIP MODULE REQUIRED)
+if(LIBZIPPP_CMAKE_CONFIG_MODE)
+  set(LIBZIP_PKGNAME "libzip")
+  set(fp_mode "CONFIG")
+else()
+  set(LIBZIP_PKGNAME "LIBZIP")
+  set(fp_mode "MODULE")
+endif()
+
+find_package(${LIBZIP_PKGNAME} ${fp_mode} REQUIRED)
 
 add_library(libzippp "src/libzippp.cpp")
 add_library(libzippp::libzippp ALIAS libzippp) # Convenience alias
-target_include_directories(libzippp 
-  PUBLIC  
+target_include_directories(libzippp
+  PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include/libzippp>
 )
@@ -61,7 +71,7 @@ if(LIBZIPPP_BUILD_TESTS)
   add_executable(libzippp_test "tests/tests.cpp")
   target_link_libraries(libzippp_test PRIVATE libzippp)
   add_test(NAME libzippp_tests COMMAND libzippp_test)
-  
+
   if (BUILD_SHARED_LIBS)
     set_target_properties(libzippp_test PROPERTIES OUTPUT_NAME "libzippp_shared_test")
   else()
@@ -71,11 +81,11 @@ endif()
 
 if(LIBZIPPP_INSTALL)
   install(
-    TARGETS libzippp 
+    TARGETS libzippp
     EXPORT libzipppTargets
     LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib 
-    RUNTIME DESTINATION bin 
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
   )
 
   if(LIBZIPPP_INSTALL_HEADERS)
@@ -91,10 +101,10 @@ if(LIBZIPPP_INSTALL)
   else()
     set(configInstallDestination share/${PROJECT_NAME})
   endif()
-  
+
   configure_package_config_file(
-    "Config.cmake.in" 
-    ${PROJECT_CONFIG_FILE} 
+    "Config.cmake.in"
+    ${PROJECT_CONFIG_FILE}
     INSTALL_DESTINATION ${configInstallDestination}
   )
   write_basic_package_version_file(
@@ -103,7 +113,8 @@ if(LIBZIPPP_INSTALL)
   )
 
   install(
-    FILES ${PROJECT_CONFIG_FILE} ${PROJECT_VERSION_FILE} cmake/FindLIBZIP.cmake
+    FILES ${PROJECT_CONFIG_FILE} ${PROJECT_VERSION_FILE}
+    $<$<NOT:$<BOOL:"${LIBZIPPP_CMAKE_CONFIG_MODE}">>:cmake/FindLIBZIP.cmake>
     DESTINATION ${configInstallDestination}
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,5 +140,20 @@ if(LIBZIPPP_INSTALL)
     NAMESPACE "${PROJECT_NAME}::"
     DESTINATION ${configInstallDestination}
   )
-endif()
 
+  if(BUILD_SHARED_LIBS AND LIBZIPPP_GNUINSTALLDIRS AND LIBZIPPP_INSTALL_HEADERS)
+    string(
+      REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}" "\${prefix}"
+      pc_includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}"
+    )
+    string(
+      REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}" "\${exec_prefix}"
+      pc_libdir "${CMAKE_INSTALL_FULL_LIBDIR}"
+    )
+    configure_file(libzippp.pc.in generated/libzippp.pc @ONLY)
+    install(
+      FILES ${CMAKE_CURRENT_BINARYDIR}/generated/libzipp.pc
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.14.0)
 
 project(libzippp
         VERSION 6.0.0
@@ -36,6 +36,7 @@ option(LIBZIPPP_INSTALL_HEADERS "Install the headers" ${is_root_project})
 option(LIBZIPPP_BUILD_TESTS "Build unit tests" ${is_root_project})
 option(LIBZIPPP_ENABLE_ENCRYPTION "Build with encryption enabled" OFF)
 option(LIBZIPPP_CMAKE_CONFIG_MODE "Build with libzip installed cmake config files" ${NOTWIN32})
+option(LIBZIPPP_GNUINSTALLDIRS "Install into directories taken from GNUInstallDirs" ${UNIX})
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -49,12 +50,18 @@ endif()
 
 find_package(${LIBZIP_PKGNAME} ${fp_mode} REQUIRED)
 
+if(LIBZIPPP_GNUINSTALLDIRS)
+  include(GNUInstallDirs)
+endif()
+
 add_library(libzippp "src/libzippp.cpp")
 add_library(libzippp::libzippp ALIAS libzippp) # Convenience alias
 target_include_directories(libzippp
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:include/libzippp>
+    "$<INSTALL_INTERFACE:
+       $<IF:$<BOOL:${LIBZIPPP_GNUINSTALLDIRS}>,
+         ${CMAKE_INSTALL_INCLUDEDIR}/libzippp,include/libzippp>>"
 )
 set_target_properties(libzippp PROPERTIES PREFIX "") # Avoid duplicate "lib" prefix
 target_link_libraries(libzippp PRIVATE libzip::zip)
@@ -88,23 +95,28 @@ if(LIBZIPPP_INSTALL)
   install(
     TARGETS libzippp
     EXPORT libzipppTargets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin
   )
 
   if(LIBZIPPP_INSTALL_HEADERS)
-    install(FILES src/libzippp.h DESTINATION include/libzippp)
+    install(
+      FILES src/libzippp.h
+      DESTINATION
+      $<IF:$<BOOL:${LIBZIPPP_GNUINSTALLDIRS}>,${CMAKE_INSTALL_INCLUDEDIR}/libzippp,include/libzippp>
+    )
   endif()
 
   include(CMakePackageConfigHelpers)
 
   set(PROJECT_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}Config.cmake")
   set(PROJECT_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}ConfigVersion.cmake")
-  if(WIN32)
-    set(configInstallDestination cmake/${PROJECT_NAME})
+  if(LIBZIPPP_GNUINSTALLDIRS)
+    set(configInstallDestination ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   else()
-    set(configInstallDestination share/${PROJECT_NAME})
+    if(WIN32)
+      set(configInstallDestination cmake/${PROJECT_NAME})
+    else()
+      set(configInstallDestination share/${PROJECT_NAME})
+    endif()
   endif()
 
   configure_package_config_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,15 +28,14 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "-W -Wall -Wextra -ansi -pedantic -std=c++11")
   set(CMAKE_CXX_FLAGS_DEBUG "-g")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-  set(NOTWIN32 ON)
 endif()
 
 option(LIBZIPPP_INSTALL "Install library" ${is_root_project})
 option(LIBZIPPP_INSTALL_HEADERS "Install the headers" ${is_root_project})
 option(LIBZIPPP_BUILD_TESTS "Build unit tests" ${is_root_project})
 option(LIBZIPPP_ENABLE_ENCRYPTION "Build with encryption enabled" OFF)
-option(LIBZIPPP_CMAKE_CONFIG_MODE "Build with libzip installed cmake config files" ${NOTWIN32})
-option(LIBZIPPP_GNUINSTALLDIRS "Install into directories taken from GNUInstallDirs" ${UNIX})
+option(LIBZIPPP_CMAKE_CONFIG_MODE "Build with libzip installed cmake config files" OFF)
+option(LIBZIPPP_GNUINSTALLDIRS "Install into directories taken from GNUInstallDirs" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-project(libzippp VERSION 3.0.0)
+project(libzippp
+        VERSION 6.0.0
+        DESCRIPTION "C++ wrapper for libzip"
+        HOMEPAGE_URL "http://github.com/ctabin/libzippp"
+        LANGUAGES CXX
+)
 
 # Use C++11
 set(CMAKE_CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ find_package(${LIBZIP_PKGNAME} ${fp_mode} REQUIRED)
 
 if(LIBZIPPP_GNUINSTALLDIRS)
   include(GNUInstallDirs)
+  set(install_include_location ${CMAKE_INSTALL_INCLUDEDIR}/libzippp)
+else()
+  set(install_include_location include/libzippp)
 endif()
 
 add_library(libzippp "src/libzippp.cpp")
@@ -58,9 +61,8 @@ add_library(libzippp::libzippp ALIAS libzippp) # Convenience alias
 target_include_directories(libzippp
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    "$<INSTALL_INTERFACE:
-       $<IF:$<BOOL:${LIBZIPPP_GNUINSTALLDIRS}>,
-         ${CMAKE_INSTALL_INCLUDEDIR}/libzippp,include/libzippp>>"
+    $<INSTALL_INTERFACE:${install_include_location}>
+
 )
 set_target_properties(libzippp PROPERTIES PREFIX "") # Avoid duplicate "lib" prefix
 target_link_libraries(libzippp PRIVATE libzip::zip)
@@ -99,8 +101,7 @@ if(LIBZIPPP_INSTALL)
   if(LIBZIPPP_INSTALL_HEADERS)
     install(
       FILES src/libzippp.h
-      DESTINATION
-      $<IF:$<BOOL:${LIBZIPPP_GNUINSTALLDIRS}>,${CMAKE_INSTALL_INCLUDEDIR}/libzippp,include/libzippp>
+      DESTINATION ${install_include_location}
     )
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.0)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libzippp
         VERSION 6.0.0

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,10 +1,10 @@
 @PACKAGE_INIT@
 
-find_package(LIBZIP QUIET)
-if(NOT LIBZIP_FOUND)
+find_package(@LIBZIP_PKGNAME@ QUIET)
+if(NOT @LIBZIP_PKGNAME@_FOUND)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
     include(CMakeFindDependencyMacro)
-    find_dependency(LIBZIP REQUIRED)
+    find_dependency(@LIBZIP_PKGNAME@ REQUIRED)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Set via commandline as `cmake -DNAME=VALUE <other opts>` or via CMake GUI or CCM
 - `LIBZIPPP_INSTALL_HEADERS`: Enable/Disable installation of libzippp headers. Default is OFF when using via `add_subdirectory`, else ON
 - `LIBZIPPP_BUILD_TESTS`: Enable/Disable building libzippp tests. Default is OFF when using via `add_subdirectory`, else ON
 - `LIBZIPPP_ENABLE_ENCRYPTION`: Enable/Disable building libzippp with encryption capabilities. Default is OFF.
+- `LIBZIPPP_CMAKE_CONFIG_MODE`: Enable/Disable building with libzip installed cmake config files. Default is OFF.
+- `LIBZIPPP_GNUINSTALLDIRS`: Enable/Disable building with install directories taken from [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html). Default is OFF.
 - `CMAKE_INSTALL_PREFIX`: Where to install the project to
 - `CMAKE_BUILD_TYPE`: Set to Release or Debug to build with or without optimizations
 - `CMAKE_PREFIX_PATH`: Colon-separated list of prefix paths (paths containing `lib` and `include` folders) for installed libs to be used by this

--- a/cmake/FindLIBZIP.cmake
+++ b/cmake/FindLIBZIP.cmake
@@ -9,13 +9,13 @@ mark_as_advanced(LIBZIP_LIBRARY)
 get_filename_component(_libzip_libdir ${LIBZIP_LIBRARY} DIRECTORY)
 find_file(_libzip_pkgcfg libzip.pc
     HINTS ${_libzip_libdir} ${LIBZIP_INCLUDE_DIR}/..
-    PATH_SUFFIXES pkgconfig lib/pkgconfig
+    PATH_SUFFIXES pkgconfig lib/pkgconfig libdata/pkgconfig
     NO_DEFAULT_PATH
 )
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-    LIBZIP 
+    LIBZIP
     REQUIRED_VARS
         LIBZIP_LIBRARY
         LIBZIP_INCLUDE_DIR
@@ -42,15 +42,15 @@ if (LIBZIP_FOUND)
             set_property(TARGET libzip::zip APPEND PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::Crypto)
         endif()
         if(_have_extra_libs MATCHES "-lgnutls")
-            find_package(GnuTLS::GnuTLS REQUIRED)
+            find_package(GnuTLS REQUIRED)
             set_property(TARGET libzip::zip APPEND PROPERTY INTERFACE_LINK_LIBRARIES GnuTLS::GnuTLS)
         endif()
-        if(_have_extra_libs MATCHES "lgnutls")
-            find_package(Nettle::Nettle REQUIRED)
+        if(_have_extra_libs MATCHES "-lnettle")
+            find_package(Nettle REQUIRED)
             set_property(TARGET libzip::zip APPEND PROPERTY INTERFACE_LINK_LIBRARIES Nettle::Nettle)
         endif()
         if(_have_extra_libs MATCHES "-llzma")
-            find_package(LibLZMA::LibLZMA REQUIRED)
+            find_package(LibLZMA REQUIRED)
             set_property(TARGET libzip::zip APPEND PROPERTY INTERFACE_LINK_LIBRARIES LibLZMA::LibLZMA)
         endif()
         if(_have_extra_libs MATCHES "-lz")

--- a/libzippp.pc.in
+++ b/libzippp.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=@pc_includedir@
+libdir=@pc_libdir@
+
+Name: libzippp
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+
+Libs: -L${libdir} -lzippp
+Cflags: -I${includedir}

--- a/src/libzippp.h
+++ b/src/libzippp.h
@@ -35,7 +35,9 @@
   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
   IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-
+#ifndef _WIN32
+#include <cstdint>
+#endif
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -64,11 +66,11 @@ struct zip_source;
         #define LIBZIPPP_SHARED_LIBRARY_IMPORT
 #else
         //standard ISO c++ does not support long long
-        typedef long int libzippp_int64;
-        typedef unsigned long int libzippp_uint64;
-        typedef unsigned int libzippp_uint32;
-        typedef unsigned short libzippp_uint16;
-        
+        typedef std::int64_t libzippp_int64;
+        typedef std::uint64_t libzippp_uint64;
+        typedef std::uint32_t libzippp_uint32;
+        typedef std::uint16_t libzippp_uint16;
+
         #define LIBZIPPP_SHARED_LIBRARY_EXPORT
         #define LIBZIPPP_SHARED_LIBRARY_IMPORT
 #endif

--- a/tests/exampleProject/CMakeLists.txt
+++ b/tests/exampleProject/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.8.0)
 project(libzippp_example_project)
 
-find_package(libzippp 3.0 REQUIRED)
+find_package(libzippp 6.0 REQUIRED)
 
 enable_testing()
 add_executable(example "../tests.cpp")


### PR DESCRIPTION
Hi here are some fixes for packaging on GNU/Unix-like systems. It also fixes #97, that I have also come across when packaging libzippp for pkgsrc-wip. It also includes libzippp_*int* fixes for GNU/Unix-like systems, long int is 32-bits on 32bit FreeBSD and Linux. Mentioning @yurivict due to #97 and @vicroms  since I hope this doesn't break anything for the vcpkg build.