### PR TITLE
Fix GCC compile warnings

### DIFF
--- a/src/libzippp.cpp
+++ b/src/libzippp.cpp
@@ -124,8 +124,8 @@ namespace Helper {
 
 static void defaultErrorHandler(const std::string& message,
                                 const std::string& strerror,
-                                int zip_error_code,
-                                int system_error_code)
+                                int /*zip_error_code*/,
+                                int /*system_error_code*/)
 {
     fprintf(stderr, message.c_str(), strerror.c_str());
 }
@@ -354,7 +354,7 @@ bool ZipArchive::open(OpenMode om, bool checkConsistency) {
     return false;
 }
 
-void progress_callback(zip* archive, double progression, void* ud) {
+void progress_callback(zip* /*archive*/, double progression, void* ud) {
     ZipArchive* za = static_cast<ZipArchive*>(ud);
     vector<ZipProgressListener*> listeners = za->getProgressListeners();
     for(vector<ZipProgressListener*>::const_iterator it=listeners.begin() ; it!=listeners.end() ; ++it) {
@@ -363,7 +363,7 @@ void progress_callback(zip* archive, double progression, void* ud) {
     }
 }
 
-int progress_cancel_callback(zip *archive, void *ud) {
+int progress_cancel_callback(zip* /*archive*/, void* ud) {
     ZipArchive* za = static_cast<ZipArchive*>(ud);
     vector<ZipProgressListener*> listeners = za->getProgressListeners();
     for(vector<ZipProgressListener*>::const_iterator it=listeners.begin() ; it!=listeners.end() ; ++it) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -675,7 +675,7 @@ void test20() {
 }
 
 void test21() {
-    cout << "Running test 21..." << endl << fflush;
+    cout << "Running test 21..." << endl;
     const char* txtFile = "this is some data";   // 17 Bytes
     const char* txtFile2 = "this is some data!"; // 18 Bytes
     int len = strlen(txtFile);
@@ -893,7 +893,7 @@ void test24() {
     cout << " done." << endl;
 }
 
-int main(int argc, char** argv) {
+int main() {
     test1();  test2();  test3();  test4();  test5();
     test6();  test7();  test8();  test9();  test10();
     test11(); test12(); test13(); test14(); test15();


### PR DESCRIPTION
cmake arguments:

```
cmake -DCMAKE_BUILD_TYPE=Release ..
```

Compiler information:

```
gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0
```

Warnings:

```
$ make
[ 25%] Building CXX object CMakeFiles/libzippp.dir/src/libzippp.cpp.o
libzippp/src/libzippp.cpp: In function ‘void defaultErrorHandler(const string&, const string&, int, int)’:
libzippp/src/libzippp.cpp:127:37: warning: unused parameter ‘zip_error_code’ [-Wunused-parameter]
  127 |                                 int zip_error_code,
      |                                 ~~~~^~~~~~~~~~~~~~
libzippp/src/libzippp.cpp:128:37: warning: unused parameter ‘system_error_code’ [-Wunused-parameter]
  128 |                                 int system_error_code)
      |                                 ~~~~^~~~~~~~~~~~~~~~~
libzippp/src/libzippp.cpp: In function ‘void progress_callback(zip*, double, void*)’:
libzippp/src/libzippp.cpp:357:29: warning: unused parameter ‘archive’ [-Wunused-parameter]
  357 | void progress_callback(zip* archive, double progression, void* ud) {
      |                        ~~~~~^~~~~~~
libzippp/src/libzippp.cpp: In function ‘int progress_cancel_callback(zip*, void*)’:
libzippp/src/libzippp.cpp:366:35: warning: unused parameter ‘archive’ [-Wunused-parameter]
  366 | int progress_cancel_callback(zip *archive, void *ud) {
      |                              ~~~~~^~~~~~~
[ 50%] Linking CXX static library libzippp_static.a
[ 50%] Built target libzippp
[ 75%] Building CXX object CMakeFiles/libzippp_test.dir/tests/tests.cpp.o
libzippp/tests/tests.cpp: In function ‘void test21()’:
libzippp/tests/tests.cpp:678:45: warning: the address of ‘int fflush(FILE*)’ will never be NULL [-Waddress]
  678 |     cout << "Running test 21..." << endl << fflush;
      |                                             ^~~~~~
libzippp/tests/tests.cpp: In function ‘int main(int, char**)’:
libzippp/tests/tests.cpp:896:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
  896 | int main(int argc, char** argv) {
      |          ~~~~^~~~
libzippp/tests/tests.cpp:896:27: warning: unused parameter ‘argv’ [-Wunused-parameter]
  896 | int main(int argc, char** argv) {
      |                    ~~~~~~~^~~~
[100%] Linking CXX executable libzippp_static_test
[100%] Built target libzippp_test
```