### PR TITLE
Fix CMake typos in pkg-config install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(LIBZIPPP_INSTALL)
     )
     configure_file(libzippp.pc.in generated/libzippp.pc @ONLY)
     install(
-      FILES ${CMAKE_CURRENT_BINARYDIR}/generated/libzipp.pc
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/libzippp.pc
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
   endif()


### PR DESCRIPTION
Hi, the install of the pkg-config file included typos.