### PR TITLE
Output INTERFACE_COMPILE_DEFINITIONS to the pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,11 @@ if(LIBZIPPP_INSTALL)
       REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}" "\${exec_prefix}"
       pc_libdir "${CMAKE_INSTALL_FULL_LIBDIR}"
     )
+    get_target_property(pc_cd_list libzippp INTERFACE_COMPILE_DEFINITIONS)
+    if(pc_cd_list)
+      list(TRANSFORM pc_cd_list PREPEND "-D")
+      list(JOIN pc_cd_list " " pc_compile_definitions)
+    endif()
     configure_file(libzippp.pc.in generated/libzippp.pc @ONLY)
     install(
       FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/libzippp.pc

--- a/libzippp.pc.in
+++ b/libzippp.pc.in
@@ -9,4 +9,4 @@ URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
 
 Libs: -L${libdir} -lzippp
-Cflags: -I${includedir}
+Cflags: -I${includedir} @pc_compile_definitions@


### PR DESCRIPTION
Output INTERFACE_COMPILE_DEFINITIONS to the pkg-config file. This makes the LIBZIPPP_WITH_ENCRYPTION definition to be enabled if the CMake option LIBZIPPP_ENABLE_ENCRYPTION is enabled and the built libzippp is installed and later used via the pkg-config file.
Fixes #216 